### PR TITLE
Link the Cratis blog from the organization profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,8 @@ At the center is [**Chronicle**](https://github.com/Cratis/Chronicle), an event-
 
 Cratis is built on a simple conviction: event sourcing is worth it for almost any system that deals with information and business flows — and it should never feel exotic. Everything here is designed to make event sourcing look and feel like idiomatic code in your language, familiar even if you have never event-sourced before, with less friction and boilerplate and a focus on productivity, quality, and reliability. And it is deliberately simple: one ecosystem with the tools a team needs — AI-friendly by design, with free [AI skills](https://github.com/Cratis/AI) for building with the stack.
 
-All documentation can be found at [https://cratis.io](https://cratis.io). Want to see it running? Start with the [Samples](https://github.com/Cratis/Samples).
+All documentation can be found at [https://cratis.io](https://cratis.io).
+Engineering writing lives on the blog at [https://blog.cratis.io](https://blog.cratis.io). Want to see it running? Start with the [Samples](https://github.com/Cratis/Samples).
 
 ## The ecosystem
 


### PR DESCRIPTION
Founder-decided: link https://blog.cratis.io from all Cratis surfaces.

Adds a single Blog link line to the organization profile README, next to the documentation link.

Humans merge.