### PR TITLE
Replace the organization profile with neutral navigation

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,56 +1,37 @@
 # Cratis
 
-Cratis is synonymous with **developer friendly**, aimed at putting developers in the pit of success.
-This is done through different libraries supporting you as a developer. These libraries also feed
-the main product of Cratis; [***Chronicle***](https://github.com/cratis/chronicle) - the easy to use and flexible event sourcing database.
+Use this profile to find Cratis technical documentation, source repositories,
+examples, and community paths.
 
-All documentation can be found at [https://cratis.io](https://cratis.io).
+## Start here
 
-## Values
+- [Technical documentation](https://cratis.io/)
+- [Company, fit, and trust information](https://cratis.no/)
+- [Runnable samples](https://github.com/Cratis/Samples)
+- [Community discussion](https://discord.gg/kt4AMpV8WV)
 
-We have a belief system founded in a set of core values.
-They represent a mindset of how we approach software development and what we
-consider important. You can read more about them [here](/values.md).
+## Product repositories
 
-## Code of Conduct
+- [Arc](https://github.com/Cratis/Arc)
+- [Chronicle](https://github.com/Cratis/Chronicle)
+- [Cratis CLI](https://github.com/Cratis/cli)
+- [Components](https://github.com/Cratis/Components)
 
-Our responsibility for running the community is to provide a safe space for everyone. To assure this
-we have put together a [code of conduct](/CODE_OF_CONDUCT.md).
+Each repository owns its technical description, packages, examples, current
+limits, and release evidence. Use the canonical product pages on
+[cratis.io](https://cratis.io/) when evaluating a product.
 
-## Architectural characteristics
+## Community and contribution
 
-All that we do follows a set of [characteristics](/characteristics.md) that we use as guiding stars.
-These are characteristics we are building towards and will also be what we look at for contributions.
+- [Values](https://github.com/Cratis/.github/blob/main/values.md)
+- [Architectural characteristics](https://github.com/Cratis/.github/blob/main/characteristics.md)
+- [Code of Conduct](https://github.com/Cratis/.github/blob/main/CODE_OF_CONDUCT.md)
+- [Contribution guide](https://github.com/Cratis/.github/blob/main/contributing.md)
+- [Security policy](https://github.com/Cratis/.github/blob/main/SECURITY.md)
 
-## Contributing
+Licenses vary by repository and package. Review the exact `LICENSE` file and
+package metadata for the artifact you use.
 
-We welcome contributions to our journey, we have put to gether a [contribution guide](/contributing.md)
-to help in setting what our expectations are for contributions.
-
-## Versions
-
-### Chronicle
-
-[![Nuget](https://img.shields.io/nuget/v/Cratis.Chronicle?label=Cratis.Chronicle&logo=nuget)](http://nuget.org/packages/cratis.chronicle)
-[![Docker](https://img.shields.io/docker/v/cratis/chronicle?label=Chronicle&logo=docker&sort=semver)](https://hub.docker.com/r/cratis/chronicle)
-
-### Arc
-
-[![Nuget](https://img.shields.io/nuget/v/Cratis.Arc?label=Cratis.Arc&logo=nuget)](http://nuget.org/packages/cratis.arc)
-[![NPM](https://img.shields.io/npm/v/@cratis/arc?label=@cratis/arc&logo=npm)](https://www.npmjs.com/package/@cratis/arc)
-
-### Fundamentals
-
-[![Nuget](https://img.shields.io/nuget/v/Cratis.Fundamentals?label=Cratis.Fundamentals&logo=nuget)](http://nuget.org/packages/cratis.fundamentals)
-[![NPM](https://img.shields.io/npm/v/@cratis/fundamentals?label=@cratis/fundamentals&logo=npm)](https://www.npmjs.com/package/@cratis/fundamentals)
-
-### Components
-
-[![NPM](https://img.shields.io/npm/v/@cratis/components?label=@cratis/components&logo=npm)](https://www.npmjs.com/package/@cratis/components)
-
-### Specifications
-
-[![Nuget](https://img.shields.io/nuget/v/cratis.specifications.xunit?label=XUnit)](http://nuget.org/packages/cratis.specifications.xunit)
-[![Nuget](https://img.shields.io/nuget/v/cratis.specifications.nunit?label=NUnit)](http://nuget.org/packages/cratis.specifications.nunit)
-
-
+Repository activity, packages, builds, examples, and documentation do not
+establish maturity, compatibility, security, performance, support, or
+production suitability.


### PR DESCRIPTION
Draft — surfacing work that was pushed on 2026-08-25 but never proposed, so nobody has reviewed it.

Rewrites `profile/README.md`: 26 insertions, 45 deletions, replacing the organization profile with neutral navigation.

This is the GitHub org profile — the first thing visitors see — so it is a public-facing branding decision rather than a routine change. Opening as a draft for a deliberate call rather than merging it silently.

I found it while auditing branches with no associated PR. I have not evaluated the wording itself.